### PR TITLE
Added flag to send M600 only once for each detection

### DIFF
--- a/octoprint_filamentsensorng/templates/filamentsensorng_settings.jinja2
+++ b/octoprint_filamentsensorng/templates/filamentsensorng_settings.jinja2
@@ -59,4 +59,17 @@
             </label>
         </div>
     </div>
+    <div class="control-group">
+        <div class="controls" data-toggle="tooltip" title="{{ _('With this option checked, the plugin will ignore subsequent reports of out of filament until the print is resumed again.') }}">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.filamentsensorng.send_gcode_only_once"> {{ _('Send GCODE only once when out of filament. This flag resets every 5 minutes') }}
+            </label>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label">{{ _('Trigger timeout:') }}</label>
+        <div class="controls" data-toggle="tooltip" title="{{ _('How long (in seconds) ignore subsequent triggers') }}">
+            <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.filamentsensorng.trigger_timeout">
+        </div>
+    </div>
 </form>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_filamentsensorng"
 plugin_name = "Octoprint-FilamentSensor-ng"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.2"
+plugin_version = "1.0.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Hello:

I added functionallity to be able to flag when the filament sensor is triggered so it only triggers once. I did this by adding a configurable option to do so and define the ammount of seconds the sensor triggers should be ignored.

Other solutions just stop detecting new triggers once the first one is detected, but that will cause the sensor to work just once per printing session. 

Without this code mine was entering a pause loop since it was triggering while doing the filament swap. This addition fixed that. 

Ángel